### PR TITLE
Compatibility with gnome-shell 3.4.2

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,8 +5,5 @@
     "description": "Shows all running emacs servers and allows connecting to them.",
     "original-authors": ["localvoid@gmail.com"],
     "url": "http://github.com/localvoid/gnome-shell-emacsmanager",
-    "shell-version": [
-        "3.4.1",
-        "3.4.2"
-        ]
+    "shell-version": ["3.4"]
 }


### PR DESCRIPTION
On Arch Linux the up-to-date `gnome-shell` is 3.4.2 currently - which is not specified in the `metadata.json`.

Please find the attached modification which only updates `shell-version`. I have two commits in there, both should work IMHO:
- adding `3.4.2` to version
- only specifying `3.4` there

I am not sure which would you prefer.
