### PR TITLE
Port to GNOME Shell 3.32.

### DIFF
--- a/autocomplete.js
+++ b/autocomplete.js
@@ -1,4 +1,3 @@
-const Lang = imports.lang;
 const Signals = imports.signals;
 
 const GLib = imports.gi.GLib;
@@ -13,10 +12,9 @@ const Monitor = Ext.imports.monitor;
 
 const DESKTOP_FILENAME_REGEXP = /^([^\.]+)\.desktop$/;
 
-const RunCompleter = new Lang.Class({
-    Name: 'EmacsManager.RunCompleter',
+const RunCompleter = class {
 
-    _init: function() {
+    constructor() {
         this._desktops = [];
 
         Utils.eachFile(Settings.EMACS_DESKTOP_DIR, function(f) {
@@ -34,26 +32,26 @@ const RunCompleter = new Lang.Class({
         m.connect('deleted', this._onFileDeleted.bind(this));
 
         m.enable();
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this._monitor.disable();
-    },
+    }
 
-    _onFileCreated: function(source, info) {
+    _onFileCreated(source, info) {
         let name = info.get_basename();
         let match = DESKTOP_FILENAME_REGEXP.exec(name);
 
         if (match) {
             this._desktops.push(match[1]);
         }
-    },
+    }
 
-    _onFileDeleted: function(source, info) {
+    _onFileDeleted(source, info) {
         delete this._desktops[this._desktops.indexOf(info.get_basename())];
-    },
+    }
 
-    getCompletion: function(text) {
+    getCompletion(text) {
         let common = '';
         let notInit = true;
         let items = this._desktops;
@@ -74,9 +72,9 @@ const RunCompleter = new Lang.Class({
         }
 
         return common;
-    },
+    }
 
-    _getCommon: function(s1, s2) {
+    _getCommon(s1, s2) {
         if (s1 === null) {
             return s2;
         }
@@ -92,4 +90,4 @@ const RunCompleter = new Lang.Class({
         }
         return s1.substr(0, k);
     }
-});
+};

--- a/extension.js
+++ b/extension.js
@@ -1,5 +1,3 @@
-const Lang = imports.lang;
-
 const ExtUtils = imports.misc.extensionUtils;
 const Ext = ExtUtils.getCurrentExtension();
 
@@ -7,10 +5,9 @@ const Core = Ext.imports.core;
 const Autocomplete = Ext.imports.autocomplete;
 const Views = Ext.imports.views;
 
-const Extension = new Lang.Class({
-    Name: 'EmacsManager.Extension',
+const Extension = class {
 
-    enable: function() {
+    enable() {
         try {
             this._emacsManager = new Core.EmacsManager();
             this._runCompleter = new Autocomplete.RunCompleter();
@@ -29,9 +26,9 @@ const Extension = new Lang.Class({
 
             throw e;
         }
-    },
+    }
 
-    disable: function() {
+    disable() {
         this._view.destroy();
         this._runCompleter.destroy();
         this._emacsManager.destroy();
@@ -40,7 +37,7 @@ const Extension = new Lang.Class({
         this._runCompleter = null;
         this._emacsManager = null;
     }
-});
+};
 
 function init(metadata) {
     return new Extension();

--- a/metadata.json
+++ b/metadata.json
@@ -5,5 +5,5 @@
     "description": "Manage local emacs server instances from status bar",
     "original-authors": ["localvoid@gmail.com"],
     "url": "http://github.com/localvoid/gnome-shell-emacsmanager",
-    "shell-version": ["3.14"]
+    "shell-version": ["3.32"]
 }

--- a/monitor.js
+++ b/monitor.js
@@ -1,16 +1,14 @@
 const Gio = imports.gi.Gio;
 const Signals = imports.signals;
-const Lang = imports.lang;
 
-const DirectoryMonitor = new Lang.Class({
-    Name: 'EmacsManager.DirectoryMonitor',
+const DirectoryMonitor = class {
 
-    _init: function(path) {
+    constructor(path) {
         this.path = path;
         this._monitor = null;
-    },
+    }
 
-    enable: function() {
+    enable() {
         if (!this._monitor) {
             this._file = Gio.file_new_for_path(this.path);
             try {
@@ -21,16 +19,16 @@ const DirectoryMonitor = new Lang.Class({
                 logError(e, 'failed to register file monitor');
             }
         }
-    },
+    }
 
-    disable: function() {
+    disable() {
         if (this._monitor) {
             this._monitor.cancel();
             this._monitor = null;
         }
-    },
+    }
 
-    _onChanged: function(monitor, file, otherFile, eventType) {
+    _onChanged(monitor, file, otherFile, eventType) {
         switch (eventType) {
         case Gio.FileMonitorEvent.CREATED:
             if (file.get_path() === this.path)
@@ -43,6 +41,6 @@ const DirectoryMonitor = new Lang.Class({
             break;
         }
     }
-});
+};
 
 Signals.addSignalMethods(DirectoryMonitor.prototype);

--- a/views.js
+++ b/views.js
@@ -1,6 +1,7 @@
 const Lang = imports.lang;
 const Signals = imports.signals;
 
+const GObject = imports.gi.GObject;
 const Pango = imports.gi.Pango;
 const Clutter = imports.gi.Clutter;
 const St = imports.gi.St;
@@ -16,12 +17,10 @@ const Main = imports.ui.main;
 const DIALOG_GROW_TIME = 0.1;
 
 
-const RunDialog = new Lang.Class({
-    Name: 'EmacsManager.RunDialog',
-    Extends: ModalDialog.ModalDialog,
+const RunDialog = class extends ModalDialog.ModalDialog {
 
-    _init: function(emacsManager, completer) {
-        this.parent({ styleClass: 'run-dialog',
+    constructor(emacsManager, completer) {
+        super({ styleClass: 'run-dialog',
                       destroyOnClose: false });
 
         this._emacsManager = emacsManager;
@@ -81,9 +80,9 @@ const RunDialog = new Lang.Class({
         this.setButtons([{ action: this.close.bind(this),
                            label: _('Close'),
                            key: Clutter.Escape }]);
-    },
+    }
 
-    _onKeyPress: function(o, e) {
+    _onKeyPress(o, e) {
         let symbol = e.get_key_symbol();
 
         if (symbol == Clutter.Return || symbol == Clutter.KP_Enter) {
@@ -111,13 +110,13 @@ const RunDialog = new Lang.Class({
             return Clutter.EVENT_STOP;
         }
         return Clutter.EVENT_PROPAGATE;
-    },
+    }
 
-    _getCompletion: function(text) {
+    _getCompletion(text) {
         return this._completer.getCompletion(text);
-    },
+    }
 
-    _run : function(input) {
+    _run(input) {
         this._commandError = false;
 
         if (input) {
@@ -127,9 +126,9 @@ const RunDialog = new Lang.Class({
                 this._showError(e.message);
             }
         }
-    },
+    }
 
-    _showError : function(message) {
+    _showError(message) {
         this._commandError = true;
         this._errorMessage.set_text(message);
 
@@ -149,22 +148,20 @@ const RunDialog = new Lang.Class({
                                       })
             });
         }
-    },
+    }
 
-    open: function() {
+    open() {
         this._errorBox.hide();
         this._entryText.set_text('');
         this._commandError = false;
-        this.parent();
+        super.open();
     }
-});
+};
 
-const RemoteServerView = new Lang.Class({
-    Name: 'EmacsManager.RemoteServerView',
-    Extends: PopupMenu.PopupBaseMenuItem,
+const RemoteServerView = class extends PopupMenu.PopupBaseMenuItem {
 
-    _init: function(server) {
-        this.parent();
+    constructor(server) {
+        super();
 
         this.server = server;
 
@@ -179,19 +176,17 @@ const RemoteServerView = new Lang.Class({
         }));
 
         this.connect('activate', this._onActivate.bind(this));
-    },
+    }
 
-    _onActivate: function(e, c) {
+    _onActivate(e, c) {
         this.server.startClient();
     }
-});
+};
 
-const ServerView = new Lang.Class({
-    Name: 'EmacsManager.ServerView',
-    Extends: PopupMenu.PopupBaseMenuItem,
+const ServerView = class extends PopupMenu.PopupBaseMenuItem {
 
-    _init: function(server) {
-        this.parent();
+    constructor(server) {
+        super();
 
         this.server = server;
         server.connect('state-changed', this._onStateChanged.bind(this));
@@ -215,34 +210,32 @@ const ServerView = new Lang.Class({
         this.actor.add(killButton, { span: -1, align: St.Align.END });
 
         this.connect('activate', this._onActivate.bind(this));
-    },
+    }
 
-    _onKill: function(e) {
+    _onKill(e) {
         this.server.kill();
-    },
+    }
 
-    _syncState: function() {
+    _syncState() {
         if (this.server.state === 'RUNNING')
             this.setSensitive(true);
         else
             this.setSensitive(false);
-    },
+    }
 
-    _onStateChanged: function(source, state) {
+    _onStateChanged(source, state) {
         this._syncState();
-    },
+    }
 
-    _onActivate: function(e, c) {
+    _onActivate(e, c) {
         this.server.startClient();
     }
-});
+};
 
-const RemoteServerListView = new Lang.Class({
-    Name: 'EmacsManager.RemoteServerListView',
-    Extends: PopupMenu.PopupMenuSection,
+const RemoteServerListView = class extends PopupMenu.PopupMenuSection {
 
-    _init: function(emacsManager) {
-        this.parent();
+    constructor(emacsManager) {
+        super();
 
         this.serverCount = 0;
         this._serverViews = {};
@@ -257,36 +250,34 @@ const RemoteServerListView = new Lang.Class({
             let s = servers[name];
             this._createServer(s);
         }
-    },
+    }
 
-    _createServer: function(srv) {
+    _createServer(srv) {
         this.serverCount += 1;
         let v = new RemoteServerView(srv);
         this._serverViews[srv.name] = v;
         this.addMenuItem(v);
         if (this.serverCount === 1)
             this.emit('empty', false);
-    },
+    }
 
-    _onServerCreated: function(source, srv) {
+    _onServerCreated(source, srv) {
         this._createServer(srv);
-    },
+    }
 
-    _onServerDeleted: function(source, srv) {
+    _onServerDeleted(source, srv) {
         this.serverCount -= 1;
         this._serverViews[srv.name].destroy();
         delete this._serverViews[srv];
         if (this.serverCount === 0)
             this.emit('empty', true);
     }
-});
+};
 
-const ServerListView = new Lang.Class({
-    Name: 'EmacsManager.ServerListView',
-    Extends: PopupMenu.PopupMenuSection,
+const ServerListView = class extends PopupMenu.PopupMenuSection {
 
-    _init: function(emacsManager) {
-        this.parent();
+    constructor(emacsManager) {
+        super();
 
         this.serverCount = 0;
         this._serverViews = {};
@@ -301,53 +292,49 @@ const ServerListView = new Lang.Class({
             let s = servers[name];
             this._createServer(s);
         }
-    },
+    }
 
-    _createServer: function(srv) {
+    _createServer(srv) {
         this.serverCount += 1;
         let v = new ServerView(srv);
         this._serverViews[srv.name] = v;
         this.addMenuItem(v);
         if (this.serverCount === 1)
             this.emit('empty', false);
-    },
+    }
 
-    _onServerCreated: function(source, srv) {
+    _onServerCreated(source, srv) {
         this._createServer(srv);
-    },
+    }
 
-    _onServerDeleted: function(source, srv) {
+    _onServerDeleted(source, srv) {
         this.serverCount -= 1;
         this._serverViews[srv.name].destroy();
         delete this._serverViews[srv];
         if (this.serverCount === 0)
             this.emit('empty', true);
     }
-});
+};
 
 
-const MenuView = new Lang.Class({
-    Name: 'EmacsManager.MenuView',
-    Extends: PopupMenu.PopupMenuSection,
+const MenuView = class extends PopupMenu.PopupMenuSection {
 
-    _init: function(mainView) {
-        this.parent();
+    constructor(mainView) {
+        super();
         this._mainView = mainView;
         this.addAction('Start server', this._onStartServer.bind(this));
-    },
+    }
 
-    _onStartServer: function() {
+    _onStartServer() {
         this._mainView.popupStartServerDialog();
     }
-});
+};
 
 
-const StatusButton = new Lang.Class({
-    Name: 'EmacsManager.Button',
-    Extends: PanelMenu.Button,
+const StatusButton = GObject.registerClass(class EmacsManagerStatusButton extends PanelMenu.Button {
 
-    _init: function(mainView, emacsManager) {
-        this.parent(0.0, _('Emacs Manager'));
+    _init(mainView, emacsManager) {
+        super._init(0.0, _('Emacs Manager'));
 
         this._hbox = new St.BoxLayout({ style_class: 'panel-status-menu-box' });
         this._hbox.add_child(new St.Icon({ style_class: 'system-status-icon',
@@ -371,9 +358,9 @@ const StatusButton = new Lang.Class({
         this._syncEmpty();
 
         this.menu.addMenuItem(this._menuView);
-    },
+    }
 
-    _syncEmpty: function() {
+    _syncEmpty() {
         if (this._serverListView.serverCount > 0 ||
             this._remoteServerListView.serverCount > 0) {
             if (!this._separator) {
@@ -387,29 +374,28 @@ const StatusButton = new Lang.Class({
                 this._separator = null;
             }
         }
-    },
+    }
 
-    _onEmpty: function(source, isEmpty) {
+    _onEmpty(source, isEmpty) {
         this._syncEmpty();
     }
 });
 
-const View = new Lang.Class({
-    Name: 'EmacsManager.View',
+const View = class {
 
-    _init: function(emacsManager, runCompleter) {
+    constructor(emacsManager, runCompleter) {
         this._runDialog = new RunDialog(emacsManager, runCompleter);
         this._statusButton = new StatusButton(this, emacsManager);
 
         Main.panel.addToStatusArea('emacs-manager', this._statusButton);
-    },
+    }
 
-    popupStartServerDialog: function() {
+    popupStartServerDialog() {
         this._runDialog.open();
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this._statusButton.destroy();
         this._runDialog.destroy();
     }
-});
+};


### PR DESCRIPTION
GNOME Shell 3.32 removed `Lang.class()` and we should be using ES6 classes instead.
https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/361

This fixes #14.
